### PR TITLE
Improve regex for date and time in w3c formats

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -212,6 +212,9 @@ class RegexFormat(BaseFormat):
         match_result = self.regex.match(line)
         if match_result:
             self.matched = match_result.groupdict()
+            if 'time' in self.matched:
+                self.matched['date'] = self.matched['date'] + ' ' + self.matched['time']
+                del self.matched['time']
         else:
             self.matched = None
         return match_result
@@ -234,8 +237,8 @@ class W3cExtendedFormat(RegexFormat):
     FIELDS_LINE_PREFIX = '#Fields: '
 
     fields = {
-        'date': r'(?P<date>\d+[-\d+]+',
-        'time': r'[\d+:]+)[.\d]*?', # TODO should not assume date & time will be together not sure how to fix ATM.
+        'date': r'"?(?P<date>\d+[-\d+]+)"?',
+        'time': r'"?(?P<time>[\d+:]+)[.\d]*?"?',
         'cs-uri-stem': r'(?P<path>/\S*)',
         'cs-uri-query': r'(?P<query_string>\S*)',
         'c-ip': r'"?(?P<ip>[\w*.:-]*)"?',

--- a/tests/logs/splitted_date_and_time.log
+++ b/tests/logs/splitted_date_and_time.log
@@ -1,0 +1,2 @@
+#Fields: c-ip c-dns date cs-uri-stem c-status cs(User-Agent) sc-bytes x-duration avgbandwidth time
+1.2.3.4 5.6.7.8 2015-12-07 /stream?title=UKR%20Nights 200 NSPlayer%2F10.0.0.3702%20WMFSDK%2F10.0 65580 1 524640 10:37:05

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -585,6 +585,45 @@ def test_shoutcast_parsing():
     assert hits[0]['user_agent'] == u'NSPlayer/10.0.0.3702 WMFSDK/10.0'
     assert hits[0]['length'] == 65580
 
+def test_splitted_date_and_time_parsing():
+    """test parsing of logs with splitted date and time"""
+
+    file_ = 'logs/splitted_date_and_time.log'
+
+    # have to override previous globals override for this test
+    import_logs.config.options.custom_w3c_fields = {}
+    Recorder.recorders = []
+    import_logs.parser = import_logs.Parser()
+    import_logs.config.format = None
+    import_logs.config.options.enable_http_redirects = True
+    import_logs.config.options.enable_http_errors = True
+    import_logs.config.options.replay_tracking = False
+    import_logs.config.options.w3c_time_taken_in_millisecs = False
+    import_logs.parser.parse(file_)
+
+    hits = [hit.__dict__ for hit in Recorder.recorders]
+
+    assert hits[0]['status'] == u'200'
+    assert hits[0]['userid'] == None
+    assert hits[0]['is_error'] == False
+    assert hits[0]['extension'] == u'/stream'
+    assert hits[0]['is_download'] == False
+    assert hits[0]['referrer'] == ''
+    assert hits[0]['args'] == {}
+    assert hits[0]['generation_time_milli'] == 1000.0
+    assert hits[0]['host'] == 'foo'
+    assert hits[0]['filename'] == 'logs/splitted_date_and_time.log'
+    assert hits[0]['is_redirect'] == False
+    assert hits[0]['date'] == datetime.datetime(2015, 12, 7, 10, 37, 5)
+    assert hits[0]['lineno'] == 1
+    assert hits[0]['ip'] == u'1.2.3.4'
+    assert hits[0]['query_string'] == u'title=UKR%20Nights'
+    assert hits[0]['path'] == u'/stream'
+    assert hits[0]['is_robot'] == False
+    assert hits[0]['full_path'] == u'/stream?title=UKR%20Nights'
+    assert hits[0]['user_agent'] == u'NSPlayer/10.0.0.3702 WMFSDK/10.0'
+    assert hits[0]['length'] == 65580
+
 def test_elb_parsing():
     """test parsing of elb logs"""
 


### PR DESCRIPTION
currently date and time needs to be directly behind each other, as otherwise the regex would break.
This change allows to have date and time somewhere in there field order, and also allows to have it wrapped in `"`.

might help with #179 