### PR TITLE
Adding two options --add-to-date & --request-suffix

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -833,6 +833,9 @@ class Configuration(object):
             help="A number of seconds to add to each date value in the log file."
         )
         option_parser.add_option(
+            '--tracker-request-suffix', dest='tracker_request_suffix', default=None, type='string', help="Extra parameters to append to tracker requests."
+        )
+        option_parser.add_option(
             '--accept-invalid-ssl-certificate',
             dest='accept_invalid_ssl_certificate', action='store_true',
             default=False,
@@ -1361,6 +1364,9 @@ class Matomo(object):
 
             if args:
                 path = path + '?' + urllib.urlencode(args)
+
+        if config.options.tracker_request_suffix:
+            path = path + ('&' if '?' in path else '?') + config.options.tracker_request_suffix
 
         headers['User-Agent'] = 'Matomo/LogImport'
 

--- a/import_logs.py
+++ b/import_logs.py
@@ -833,7 +833,7 @@ class Configuration(object):
             help="A number of seconds to add to each date value in the log file."
         )
         option_parser.add_option(
-            '--tracker-request-suffix', dest='tracker_request_suffix', default=None, type='string', help="Extra parameters to append to tracker requests."
+            '--request-suffix', dest='request_suffix', default=None, type='string', help="Extra parameters to append to tracker and API requests."
         )
         option_parser.add_option(
             '--accept-invalid-ssl-certificate',
@@ -1365,8 +1365,8 @@ class Matomo(object):
             if args:
                 path = path + '?' + urllib.urlencode(args)
 
-        if config.options.tracker_request_suffix:
-            path = path + ('&' if '?' in path else '?') + config.options.tracker_request_suffix
+        if config.options.request_suffix:
+            path = path + ('&' if '?' in path else '?') + config.options.request_suffix
 
         headers['User-Agent'] = 'Matomo/LogImport'
 

--- a/import_logs.py
+++ b/import_logs.py
@@ -828,7 +828,10 @@ class Configuration(object):
             '--exclude-newer-than', action='callback', type='string', default=None, callback=functools.partial(self._set_date, 'exclude_newer_than'),
             help="Ignore logs newer than the specified date. Exclusive. Date format must be YYYY-MM-DD hh:mm:ss +/-0000. The timezone offset is required."
         )
-
+        option_parser.add_option(
+            '--add-to-date', dest='seconds_to_add_to_date', default=0, type='int',
+            help="A number of seconds to add to each date value in the log file."
+        )
         option_parser.add_option(
             '--accept-invalid-ssl-certificate',
             dest='accept_invalid_ssl_certificate', action='store_true',
@@ -2427,6 +2430,7 @@ class Parser(object):
             date_string = format.get('date')
             try:
                 hit.date = datetime.datetime.strptime(date_string, format.date_format)
+                hit.date += datetime.timedelta(seconds = config.options.seconds_to_add_to_date)
             except ValueError as e:
                 invalid_line(line, 'invalid date or invalid format: %s' % str(e))
                 continue

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -193,7 +193,7 @@ class Options(object):
     exclude_newer_than = None
     track_http_method = True
     seconds_to_add_to_date = 0
-    tracker_request_suffix = None
+    request_suffix = None
 
 class Config(object):
     """Mock configuration."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -192,6 +192,8 @@ class Options(object):
     exclude_older_than = None
     exclude_newer_than = None
     track_http_method = True
+    seconds_to_add_to_date = 0
+    tracker_request_suffix = None
 
 class Config(object):
     """Mock configuration."""


### PR DESCRIPTION
Changes:

* Added the `--add-to-date` option which takes a number of seconds. This is value added to every tracker request's date so the requests seem newer then the dates in the logs.
* Added the `--request-suffix` option which appends a string to the query string for requests sent to Matomo. This can be used to mark requests that the log importer sends, so they can be identified in, for example, a plugin event. For example, I could add `reset=1` to every request so my `Tracker.getDatabaseConfig` event handler will know when we're in a tracker request made by that specific log importer execution.