### PR TITLE
Convert multidimensional query parameter args in URLs correctly

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1930,20 +1930,6 @@ class Recorder(object):
             result.append(d[str(i)])
         return result
 
-    def _add_custom_vars_from_regex_groups(self, hit, format, groups, is_page_var):
-        for group_name, custom_var_name in groups.iteritems():
-            if group_name in format.get_all():
-                value = format.get(group_name)
-
-                # don't track the '-' empty placeholder value
-                if value == '-':
-                    continue
-
-                if is_page_var:
-                    hit.add_page_custom_var(custom_var_name, value)
-                else:
-                    hit.add_visit_custom_var(custom_var_name, value)
-
     def _get_host_with_protocol(self, host, main_url):
         if '://' not in host:
             parts = urlparse.urlparse(main_url)
@@ -2564,6 +2550,20 @@ class Parser(object):
         # add last chunk of hits
         if len(hits) > 0:
             Recorder.add_hits(hits)
+
+    def _add_custom_vars_from_regex_groups(self, hit, format, groups, is_page_var):
+        for group_name, custom_var_name in groups.iteritems():
+            if group_name in format.get_all():
+                value = format.get(group_name)
+
+                # don't track the '-' empty placeholder value
+                if value == '-':
+                    continue
+
+                if is_page_var:
+                    hit.add_page_custom_var(custom_var_name, value)
+                else:
+                    hit.add_visit_custom_var(custom_var_name, value)
 
 def main():
     """

--- a/import_logs.py
+++ b/import_logs.py
@@ -1675,8 +1675,6 @@ class Recorder(object):
     the API.
     """
 
-    PHP_ARRAY_QUERY_PARAM_REGEX = re.compile('^(.*?)((?:\[.*?\])+)$')
-
     recorders = []
 
     def __init__(self):
@@ -1864,41 +1862,7 @@ class Recorder(object):
         if '_cvar' in args and not isinstance(args['_cvar'], basestring):
             args['_cvar'] = json.dumps(args['_cvar'])
 
-        return self._convert_array_args(args)
-
-    def _convert_array_args(self, args):
-        # parse array arguments which do not exist outside of php
-        final_args = {}
-        for key, value in args.iteritems():
-              m = Recorder.PHP_ARRAY_QUERY_PARAM_REGEX.match(key)
-              if m:
-                  name = m.group(1)
-                  indices = m.group(2)
-
-                  indices = indices.split('][')
-                  indices[0] = indices[0].lstrip('[')
-                  indices[-1] = indices[-1].rstrip(']')
-                  indices.insert(0, name)
-
-                  element = final_args
-                  for i in range(0, len(indices) - 1):
-                      idx = indices[i]
-                      if not indices[i + 1]:
-                          if name not in element or not isinstance(element[idx], list):
-                              element[idx] = []
-                      else:
-                          if name not in element or not isinstance(element[idx], dict):
-                              element[idx] = {}
-
-                      element = element[idx]
-
-                  if not indices[-1]:
-                      element.append(value)
-                  else:
-                      element[indices[-1]] = value
-              else:
-                  final_args[key] = value
-        return final_args
+        return args
 
     def _get_host_with_protocol(self, host, main_url):
         if '://' not in host:
@@ -2042,6 +2006,8 @@ class Parser(object):
     The Parser parses the lines in a specified file and inserts them into
     a Queue.
     """
+
+    PHP_ARRAY_QUERY_PARAM_REGEX = re.compile('^(.*?)((?:\[.*?\])+)$')
 
     def __init__(self):
         self.check_methods = [method for name, method
@@ -2496,6 +2462,7 @@ class Parser(object):
                     continue
 
                 query_arguments = urlparse.parse_qs(hit.query_string)
+                query_arguments = self._convert_array_args(query_arguments)
                 if not "idsite" in query_arguments:
                     invalid_line(line, 'missing idsite')
                     continue
@@ -2520,6 +2487,65 @@ class Parser(object):
         # add last chunk of hits
         if len(hits) > 0:
             Recorder.add_hits(hits)
+
+    def _convert_array_args(self, args):
+        # parse array arguments which do not exist outside of php
+        final_args = {}
+        for key, value in args.iteritems():
+            m = Parser.PHP_ARRAY_QUERY_PARAM_REGEX.match(key)
+            if m:
+                name = m.group(1)
+                indices = m.group(2)
+
+                indices = indices.split('][')
+                indices[0] = indices[0].lstrip('[')
+                indices[-1] = indices[-1].rstrip(']')
+                indices.insert(0, name)
+
+                element = final_args
+                for i in range(0, len(indices) - 1):
+                    idx = indices[i]
+                    if not indices[i + 1]:
+                        if idx not in element or not isinstance(element[idx], list):
+                            element[idx] = []
+                    else:
+                        if idx not in element or not isinstance(element[idx], dict):
+                            element[idx] = {}
+
+                    element = element[idx]
+
+                if not indices[-1]:
+                    element.append(value)
+                else:
+                    element[indices[-1]] = value
+            else:
+                final_args[key] = value
+
+        return self._convert_dicts_to_arrays(final_args)
+
+    def _convert_dicts_to_arrays(self, d):
+        for key, value in d.iteritems():
+            if not isinstance(value, dict):
+                continue
+
+            if self._has_contiguous_int_keys(value):
+                d[key] = self._convert_dict_to_array(value)
+            else:
+                d[key] = self._convert_dicts_to_arrays(value)
+
+        return d
+
+    def _has_contiguous_int_keys(self, d):
+        for i in range(0, len(d)):
+            if str(i) not in d:
+                return False
+        return True
+
+    def _convert_dict_to_array(self, d):
+        result = []
+        for i in range(0, len(d)):
+            result.append(d[str(i)])
+        return result
 
     def _add_custom_vars_from_regex_groups(self, hit, format, groups, is_page_var):
         for group_name, custom_var_name in groups.iteritems():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -903,7 +903,7 @@ def test_urlhelper_convert_array_args():
     f.description = 'without array args'
     yield f
 
-    f = functools.partial(_test, {'abc[]': 'def', 'ghi': 23}, {'abc[]': 'def', 'ghi': 23})
+    f = functools.partial(_test, {'abc[]': 'def', 'ghi': 23}, {'abc': ['def'], 'ghi': 23})
     f.description = 'with normal array args'
     yield f
 
@@ -921,5 +921,5 @@ def test_urlhelper_convert_array_args():
     yield f
 
     f = functools.partial(_test, {'abc[key1][3]': 1, 'abc[key1][]': 23, 'ghi[key2][]': 45, 'ghi[key2][abc]': 56}, {'abc': {'key1': [23]}, 'ghi': {'key2': {'abc': 56}}})
-    f.description = 'with multiple data strucutres'
+    f.description = 'with multiple inconsistent data strucutres'
     yield f


### PR DESCRIPTION
PHP supports sending/parsing multidimensional arrays in the URL, eg:

`param[key1][key2][] = 12`

which would be parsed as:

```
[
    'key1' => [
        'key2' => [
            12,
        ],
    ],
]
```

Python does not, so if you're replaying logs for a plugin that uses multidimensional array tracker query parameters, the replay will fail.

This fixes the issue by converting such parameters manually. Tried also to convert the parsed query string back into a query string (which would have been far simpler), but python 2 has trouble with converting querystrings with unicode.

Note: I tried converting the string parts to unicode before calling `urllib.urlencode()` (as suggested here: https://stackoverflow.com/questions/6480723/urllib-urlencode-doesnt-like-unicode-values-how-about-this-workaround), but that results in odd test failures in ImportLogsTest.php. This change doesn't.

Core build for this PR is here: https://travis-ci.org/matomo-org/matomo/builds/372841147