### PR TITLE
fixed example crontab rule in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Your logs should be automatically rotated and stored on your webserver, for inst
 month and day).
 You can then import your logs automatically each day (at 0:01). Setup a cron job with the command:
 
-    0 1 * * * /path/to/matomo/misc/log-analytics/import-logs.py -u matomo.example.com `date --date=yesterday +/var/log/apache/access-\%Y-\%m-\%d.log`
+    1 0 * * * /path/to/matomo/misc/log-analytics/import-logs.py -u matomo.example.com `date --date=yesterday +/var/log/apache/access-\%Y-\%m-\%d.log`
 
 ## Using Basic access authentication
 


### PR DESCRIPTION
The readme shows an example crontab rule to "import your logs automatically each day (at 0:01)". However, there is a mistake in the rule below - "0 1 * * *" is actually 1:00, not 0:01.
