### PR TITLE
Fix timezone calculation for non-integer timezones

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -852,10 +852,8 @@ class Configuration(object):
         if not re.match('[-+][0-9]{4}', timezone):
             fatal_error("Invalid date value '%s': expected valid timzeone like +0100 or -1200, got '%s'" % (value, timezone))
 
-        timezone = float(timezone)
-
         date = datetime.datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
-        date -= datetime.timedelta(hours=timezone/100)
+        date -= TimeHelper.timedelta_from_timezone(timezone)
 
         setattr(parser.values, option_attr_name, date)
 
@@ -1321,6 +1319,19 @@ Processing your log data
 
     def stop_monitor(self):
         self.monitor_stop = True
+
+class TimeHelper(object):
+
+    @staticmethod
+    def timedelta_from_timezone(timezone):
+        timezone = int(timezone)
+        sign = 1 if timezone >= 0 else -1
+        n = abs(timezone)
+
+        hours = n / 100 * sign
+        minutes = n % 100 * sign
+
+        return datetime.timedelta(hours=hours, minutes=minutes)
 
 class UrlHelper(object):
 
@@ -2510,15 +2521,14 @@ class Parser(object):
 
             # Parse timezone and substract its value from the date
             try:
-                timezone = float(format.get('timezone'))
+                timezone = format.get('timezone')
+                if timezone:
+                    hit.date -= TimeHelper.timedelta_from_timezone(timezone)
             except BaseFormatException:
-                timezone = 0
+                pass
             except ValueError:
                 invalid_line(line, 'invalid timezone')
                 continue
-
-            if timezone:
-                hit.date -= datetime.timedelta(hours=timezone/100)
 
             if config.options.replay_tracking:
                 # we need a query string and we only consider requests with piwik.php

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -924,6 +924,23 @@ def test_urlhelper_convert_array_args():
     f.description = 'with multiple inconsistent data strucutres'
     yield f
 
+# TimeHelper tests
+def test_timedelta_from_timezone():
+    def _test(input, expected):
+        delta = import_logs.TimeHelper.timedelta_from_timezone(input)
+        assert delta == datetime.timedelta(0, expected)
+
+    _test('+0200', 7200)
+    _test('+1400', 50400)
+    _test('+0045', 2700)
+    _test('+0330', 12600)
+    _test('+0000', 0)
+    _test('-0500', -18000)
+    _test('-1200', -43200)
+    _test('-0040', -2400)
+    _test('-0230', -9000)
+    _test('-0000', 0)
+
 # Matomo error test
 def test_matomo_error_construct():
     """Test that Matomo exception can be created."""


### PR DESCRIPTION
There are two places in the code which apply a timezone difference to a parsed date: when parsing command line arguments (`Configuration._set_date`) and when processing a hit (`Parser.parse`). They do that in a rather hacky way: the timezone is parsed as a number and then the difference is set to be `number / 100` hours.

This kind of works... except it assumes that timezones can only be at full integer intervals, and that's not true. There are several non-integer timezones, including in such important countries as India (+05:30) or Iran (+03:30). In that case, `"0530"` is interpreted as 5.3 hours ahead of UTC instead of 5.5...

For example, with such log line:

`1.2.3.4 - - [29/Nov/2018:15:30:00 +0530] "GET / HTTP/1.1" 200 6355 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0" 0.014`

the 15:30 Indian Standard Time should be read as 10:00 UTC (11:00 CET). Instead, it's 11:12:

<img width="479" alt="screenshot 2018-11-29 at 17 18 41" src="https://user-images.githubusercontent.com/28465/49235465-d37b8680-f402-11e8-9f88-3043ce41c1e5.png">

This PR makes a relatively small fix to the timezone calculating logic in that the parsed "number" (not really an actual number) e.g. `530` is divided into hours and minutes separately using integer division and modulo and passed to `datetime.timedelta` as separate parameters. With that change, the timestamp is parsed as 10:00 UTC (11:00 CET) correctly:

<img width="469" alt="screenshot 2018-11-29 at 17 52 48" src="https://user-images.githubusercontent.com/28465/49235632-340ac380-f403-11e8-84a4-f069c6a8c93a.png">
