### PR TITLE
fixed robots.txt not being counted as static file

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -66,7 +66,11 @@ except ImportError:
 ##
 
 STATIC_EXTENSIONS = set((
-    'gif jpg jpeg png bmp ico svg svgz ttf otf eot woff woff2 class swf css js xml robots.txt webp'
+    'gif jpg jpeg png bmp ico svg svgz ttf otf eot woff woff2 class swf css js xml webp'
+).split())
+
+STATIC_FILES = set((
+    'robots.txt'
 ).split())
 
 DOWNLOAD_EXTENSIONS = set((
@@ -2101,7 +2105,9 @@ class Parser(object):
         return result
 
     def check_static(self, hit):
-        if hit.extension in STATIC_EXTENSIONS:
+        filename = hit.path.split('/')[-1]
+
+        if hit.extension in STATIC_EXTENSIONS or filename in STATIC_FILES:
             if config.options.enable_static:
                 hit.is_download = True
                 return True


### PR DESCRIPTION
The `robots.txt` file is listed in the `STATIC_EXTENSIONS` list, however the entries from this list are only compared against `hit.extension` - which in case of `robots.txt` will be `txt`. So the result is that this file is not excluded from log entries and appears on the Downloads report.

This PR adds a second list of static files with full filenames (with just this one file at the moment) that's instead compared with the whole last path element of the URL.
