### PR TITLE
Clarified usage of --token-auth=<SECRET>

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The most simple way to import your logs is to run:
 
 You must specify your Matomo URL with the `--url` argument.
 The script will automatically read your config.inc.php file to get the authentication
-token and communicate with your Matomo install to import the lines.
+token and communicate with your Matomo install to import the lines. If your Matomo install is on a different server, use the `--token-auth=<SECRET>` parameter to specify your API token.
+
 The default mode will try to mimic the Javascript tracker as much as possible,
 and will not track bots, static files, or error requests.
 


### PR DESCRIPTION
When using this script with a Matomo install on a different
machine, one must include the --token-auth=<SECRET> parameter to
successfully send the logs to Matomo. This was not previously
mentioned in this particular section and is easy to overlook when
not reading about the other methods described herein.

I personally spent way too much time trying to solve this issue until
another person on irc pointed out this flag. I figured this minor edit
will save someone else from the confusion and extra research.