### PR TITLE
Compatibility with app specific tokens

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1009,9 +1009,11 @@ class Configuration(object):
 
             logging.debug('Using credentials: (login = %s, password = %s)', matomo_login, matomo_password)
             try:
-                api_result = matomo.call_api('UsersManager.getTokenAuth',
+                api_result = matomo.call_api('UsersManager.createAppSpecificTokenAuth',
                     userLogin=matomo_login,
                     md5Password=matomo_password,
+                    description='Log importer',
+                    expireHours='48',
                     _token_auth='',
                     _url=self.options.matomo_api_url,
                 )


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/6559

Will be needed in 4.x since we remove getTokenAuth method.

We need to wait for other PR to be merged before merging this