### PR TITLE
add Zabbix and GoogleStackdriverMonitoring agents

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -111,6 +111,8 @@ EXCLUDED_USER_AGENTS = (
     'voilabot',
     'yahoo',
     'yandex',
+    'zabbix',
+    'googlestackdrivermonitoring',
 )
 
 MATOMO_DEFAULT_MAX_ATTEMPTS = 3


### PR DESCRIPTION
- Zabbix is one of the best open source monitoring systems. Zabbix-agent
use "Zabbix x.x.x" (version) for http/https checks
For example: "HEAD / HTTP/1.1" 200 - "-" "Zabbix 4.4.6"
- GoogleStackdriverMonitoring - Google Cloud's operations suite is
designed to monitor, troubleshoot, and improve cloud infrastructure,
software, and application performance.
For example: "GET / HTTP/2.0" 200 5683 "-"
"GoogleStackdriverMonitoring-UptimeChecks(https://cloud.google.com/monitoring)"