### PR TITLE
Extra host from CloudFront x-host-header

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -430,7 +430,7 @@ class AmazonCloudFrontFormat(W3cExtendedFormat):
         'x-edge-location': r'(?P<x_edge_location>".*?"|\S+)',
         'x-edge-result-type': r'(?P<x_edge_result_type>".*?"|\S+)',
         'x-edge-request-id': r'(?P<x_edge_request_id>".*?"|\S+)',
-        'x-host-header': r'(?P<x_host_header>".*?"|\S+)'
+        'x-host-header': r'(?P<host>".*?"|\S+)'
     })
 
     def __init__(self):


### PR DESCRIPTION
CloudFront logs do include the host. However, without this patch,
`import_logs.py` will fail with the following error:

```
Fatal error: the selected log format doesn't include the hostname: you must specify the Matomo site ID with the --idsite argument
```