### PR TITLE
Remove colons from timezone

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -2559,7 +2559,7 @@ class Parser:
 
             # Parse timezone and subtract its value from the date
             try:
-                timezone = format.get('timezone')
+                timezone = format.get('timezone').replace(':', '')
                 if timezone:
                     hit.date -= TimeHelper.timedelta_from_timezone(timezone)
             except BaseFormatException:


### PR DESCRIPTION
Some formats include a colon in the timezone, e.g. -08:00