### PR TITLE
Make the --output option work again

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -936,7 +936,7 @@ class Configuration:
         self.filenames = self.options.file
 
         if self.options.output:
-            sys.stdout = sys.stderr = open(self.options.output, 'a+', 0)
+            sys.stdout = sys.stderr = open(self.options.output, 'a')
 
         all_filenames = []
         for self.filename in self.filenames:


### PR DESCRIPTION
### Description:

While writing some integration tests for Matomo and Log importer (see https://github.com/matomo-org/matomo/pull/17700) I realized that the `--output` option always results in a
```
Traceback (most recent call last):
  File "/srv/matomo/misc/log-analytics/import_logs.py", line 2667, in <module>
    config = Configuration()
  File "/srv/matomo/misc/log-analytics/import_logs.py", line 1029, in __init__
    self._parse_args(self._create_parser(), argv)
  File "/srv/matomo/misc/log-analytics/import_logs.py", line 939, in _parse_args
    sys.stdout = sys.stderr = open(self.options.output, 'a+', 0)
ValueError: can't have unbuffered text I/O
```

Guess that is a regression from python3 migration

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
