### PR TITLE
Fix disabling of queued tracking with bulk requests.

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -2009,7 +2009,9 @@ class Recorder:
                 'requests': [self._get_hit_args(hit) for hit in hits]
             }
             try:
-                args = {}
+                args = {
+                    'queuedtracking': '0'
+                }
 
                 if config.options.debug_tracker:
                     args['debug'] = '1'


### PR DESCRIPTION
Also fixes #319 for me.

### Description:

Bulk tracking requests were missing the query parameter to disable queued tracking. That caused imported entries to be queued. Also since queued tracking returns an image, decoding it as UTF-8 failed. 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
