### PR TITLE
Set referrer to empty string if it doesn't exist

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -2484,6 +2484,8 @@ class Parser:
             try:
                 hit.referrer = format.get('referrer')
 
+                if hit.referrer is None:
+                    hit.referrer = ''
                 if hit.referrer.startswith('"'):
                     hit.referrer = hit.referrer[1:-1]
             except BaseFormatException:


### PR DESCRIPTION
### Description:

This is a small patch to fix issue #335. Adds a check to see if the type for `hit.referrer` is None, and sets it to an empty string.

This condition happens when importing using regex format with Traefik JSON logs. Traefik omits the referrer key if the value is missing but the script does not handle it properly.

After implementing this change, the script seems to progress and read the log entries properly.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [x] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [x] Existing documentation updated if needed
