### PR TITLE
Flush hits when no activity from stdin

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -39,6 +39,7 @@ import os
 import os.path
 import queue
 import re
+import select
 import ssl
 import sys
 import threading
@@ -2506,6 +2507,13 @@ class Parser:
         hits = []
         lineno = -1
         while True:
+            has_line = lambda f: select.select([f, ], [], [], 0.0)[0]
+            if os.name == 'posix' and file == sys.stdin and not has_line(file):
+                Recorder.add_hits(hits)
+                hits = []
+                time.sleep(1)
+                continue
+
             line = file.readline()
             if not line: break
             lineno = lineno + 1


### PR DESCRIPTION
### Description:

The script only processes the logs after `len(hits) >= options.recorder_max_payload_size * len(Recorders.recorders)` valid hits are detected. With the default settings, this is 200 hits or if EOF is hit.

When the input file is `stdin` (e.g. when using syslog), and if used on a low traffic site, this makes it seem like nothing is happening, causing confusion (according to #258 and my own experiences) since the payload limit isn't hit and we never reach EOF.

I have added a check where if using `stdin` and the buffer is empty, then the current hits are sent immediately, even if we haven't reached the max payload size.

#### Caveats/potential issues/things to discuss:
- Admittedly, I haven't researched the select syscall, and the detection is based on [this](https://stackoverflow.com/a/3763257). But I can confirm on my system using syslog-ng (sorry, but I don't have any clue on how to formally test syscalls).
- This only works for Unix systems.
- I wonder if there theoretically exists a potential setting where given a very high traffic site, if the script sleeps for one second then the entire `stdin` buffer could potentially be filled?
- I have not added an option for toggling this feature, as it ideally should hopefully never be preferable to turn it off.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
