### PR TITLE
caddy_json: fix user_agent NoneType

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -318,8 +318,8 @@ class CaddyJsonFormat(BaseFormat):
         self.json['host'] = self.json['request']['host']
         self.json['method'] = self.json['request']['method']
         self.json['path'] = self.json['request']['uri']
-        self.json['referrer'] = next(iter(self.json['request']['headers'].get('Referer', [])), None)
-        self.json['user_agent'] = next(iter(self.json['request']['headers'].get('User-Agent', [])), None)
+        self.json['referrer'] = next(iter(self.json['request']['headers'].get('Referer', [])), '')
+        self.json['user_agent'] = next(iter(self.json['request']['headers'].get('User-Agent', [])), '')
         return self.json
 
     def remove_ignored_groups(self, groups):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/var/www/analytics/misc/log-analytics/import_logs.py", line 2825, in <module>
    main()
  File "/var/www/analytics/misc/log-analytics/import_logs.py", line 2791, in main
    parser.parse(filename)
  File "/var/www/analytics/misc/log-analytics/import_logs.py", line 2636, in parse
    if hit.user_agent.startswith('"'):
AttributeError: 'NoneType' object has no attribute 'startswith'
```