### PR TITLE
remove decode("utf-8") for python3 compatibility

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1722,7 +1722,7 @@ class MatomoHttpUrllib(MatomoHttpBase):
         try:
             return json.loads(res)
         except ValueError:
-            raise urllib.error.URLError('Matomo returned an invalid response: ' + res.decode("utf-8") )
+            raise urllib.error.URLError('Matomo returned an invalid response: ' + res )
 
     def _call_wrapper(self, func, expected_response, on_failure, *args, **kwargs):
         """


### PR DESCRIPTION
### Description:

When using Python 3, the `decode()` method is not needed for strings since Python 3 strings are already Unicode.

### Review

```
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 1723, in _call_api
    return json.loads(res)
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 2823, in <module>
    resolver = config.get_resolver()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 1266, in get_resolver
    return StaticResolver(self.options.site_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 1798, in __init__
    site = matomo.call_api(
           ^^^^^^^^^^^^^^^^
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 1782, in call_api
    return self._call_wrapper(self._call_api, None, None, method, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 1734, in _call_wrapper
    response = func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/example.com/htdocs/misc/log-analytics/import_logs.py", line 1725, in _call_api
    raise urllib.error.URLError('Matomo returned an invalid response: ' + res.decode("utf-8") )
                                                                          ^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

The error suggests that there's an issue with how the response from Matomo is being processed in the `import_logs.py` script. Specifically, the script is trying to decode a string that's already in Unicode format, which doesn't require decoding. 