### PR TITLE
Handle absent User-Agent

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -2631,10 +2631,10 @@ class Parser:
             try:
                 hit.user_agent = format.get('user_agent')
 
-                # in case a format parser included enclosing quotes, remove them so they are not
-                # sent to Matomo
                 if hit.user_agent is None:
                     hit.user_agent = ''
+                # in case a format parser included enclosing quotes, remove them so they are not
+                # sent to Matomo
                 if hit.user_agent.startswith('"'):
                     hit.user_agent = hit.user_agent[1:-1]
             except BaseFormatException:

--- a/import_logs.py
+++ b/import_logs.py
@@ -2633,6 +2633,8 @@ class Parser:
 
                 # in case a format parser included enclosing quotes, remove them so they are not
                 # sent to Matomo
+                if hit.user_agent is None:
+                    hit.user_agent = ''
                 if hit.user_agent.startswith('"'):
                     hit.user_agent = hit.user_agent[1:-1]
             except BaseFormatException:


### PR DESCRIPTION
### Description:

As per RFC7231 and RFC2616 User-Agent header _should_ be included, not _must_ be included, so it can be absent. If the log does not have it, the script will fail as in #380. This change addresses that.

### Review

* [X ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [X ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [X ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [X ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [X ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [X ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [X ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [X ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [X ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [X ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [X ] Existing documentation updated if needed
