### PR TITLE
Add Support for Authentication via Secure Token/Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ Security notes:
 
 Authentication methods:
 * `--auth-config` (recommended): load credentials from `[auth]` in a file (`token_auth`, or `login` + `password`).
-* `--token-auth`, `--login`, `--password` (deprecated/insecure via CLI): still supported for compatibility. `--login`/`--password` requests an app-specific token through the Matomo API.
+* `--token-auth`, `--login`, `--password` (deprecated/insecure via CLI): still supported for compatibility. `--login` and `--password` must be provided together; they request an app-specific token through the Matomo API.
 * `--config` fallback: intended for local Matomo installs, because it uses Matomo's local `misc/cron/updatetoken.php` script and a local `config.ini.php`.
+
+Authentication precedence (highest to lowest):
+* CLI `--token-auth`
+* CLI `--login` + `--password`
+* `--auth-config` (`token_auth`, or `login` + `password`)
+* `--config` fallback
 
 The default mode will try to mimic the Javascript tracker as much as possible,
 and will not track bots, static files, or error requests.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Import your server logs in Matomo with this powerful and easy to use tool.
 
 ## Requirements
 
-* Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.
+* Python 3.
 * Matomo On-Premise >= 4.0.0 or Matomo Cloud. Doesn't work when [Matomo for WordPress](https://wordpress.org/plugins/matomo/) is used.
 
 Build status (main branch) ![PHPUnit](https://github.com/matomo-org/matomo-log-analytics/workflows/Tests/badge.svg?branch=4.x-dev)
@@ -53,8 +53,36 @@ The most simple way to import your logs is to run:
     ./import_logs.py --url=matomo.example.com /path/to/access.log
 
 You must specify your Matomo URL with the `--url` argument.
-The script will automatically read your config.inc.php file to get the authentication
-token and communicate with your Matomo install to import the lines. If your Matomo install is on a different server, use the `--token-auth=<SECRET>` parameter to specify your API token.
+The importer supports several authentication methods. The recommended method is `--auth-config`.
+If no authentication is explicitly provided, the script falls back to `--config` (Matomo `config.ini.php`)
+and tries to fetch a token using local Matomo files.
+
+### Secure authentication (recommended)
+
+If your Matomo install is on a different server, use `--auth-config` and store credentials in a file instead of passing them on the command line.
+
+Example `auth.cfg`:
+```
+[auth]
+token_auth = your_token_here
+# OR
+# login = your_login_here
+# password = your_password_here
+```
+
+Then run:
+```
+./import_logs.py --url=matomo.example.com --auth-config=/path/to/auth.cfg /path/to/access.log
+```
+
+Security notes:
+* Restrict the auth config file permissions (recommended: `chmod 600 /path/to/auth.cfg`).
+* Passing secrets via CLI arguments (for example `--token-auth`, `--login`, `--password`) is deprecated and not recommended, since local users can read process arguments with tools like `ps` or `htop`.
+
+Authentication methods:
+* `--auth-config` (recommended): load credentials from `[auth]` in a file (`token_auth`, or `login` + `password`).
+* `--token-auth`, `--login`, `--password` (deprecated/insecure via CLI): still supported for compatibility. `--login`/`--password` requests an app-specific token through the Matomo API.
+* `--config` fallback: intended for local Matomo installs, because it uses Matomo's local `misc/cron/updatetoken.php` script and a local `config.ini.php`.
 
 The default mode will try to mimic the Javascript tracker as much as possible,
 and will not track bots, static files, or error requests.
@@ -66,9 +94,8 @@ If you wish to track all requests the following command would be used:
 
 ### Format Specific Details
 
-* If you are importing Netscaler log files, make sure to specify the `--iis-time-taken-secs` option. Netscaler stores
-  the time-taken field in seconds while most other formats use milliseconds. Using this option will ensure that the
-  log importer interprets the field correctly.
+* Netscaler logs commonly store W3C `time-taken` in seconds. The importer interprets W3C `time-taken` as seconds by default,
+  so no extra option is needed for that case. Use `--w3c-time-taken-millisecs` only if your `time-taken` values are milliseconds.
 
 * Some log formats can't be detected automatically as they would conflict with other formats. In order to import those logfiles make sure to specify the `--log-format-name` option.
   Those log formats are: OVH (ovh), Incapsula W3C (incapsula_w3c)
@@ -89,7 +116,7 @@ Your logs should be automatically rotated and stored on your webserver, for inst
 month and day).
 You can then import your logs automatically each day (at 0:01). Setup a cron job with the command:
 
-    1 0 * * * /path/to/matomo/misc/log-analytics/import-logs.py -u matomo.example.com `date --date=yesterday +/var/log/apache/access-\%Y-\%m-\%d.log`
+    1 0 * * * /path/to/matomo/misc/log-analytics/import_logs.py --url=matomo.example.com `date --date=yesterday +/var/log/apache/access-\%Y-\%m-\%d.log`
 
 ## Using Basic access authentication
 
@@ -267,12 +294,12 @@ if $syslogfacility-text == 'local0' then ^/usr/local/matomo/matomo.sh;matomo
 
 ###### matomo.sh, rsyslog version
 
-`/usr/local/matomo/matomo.sh`, won't work without `--token-auth` parameter:
+`/usr/local/matomo/matomo.sh` example using `--auth-config`:
 ```
 #!/bin/sh
 
 echo "${@}" | /path/to/misc/log-analytics/import_logs.py \
- --url=https://localhost/matomo/ --token-auth=<SECRET> \
+ --url=https://localhost/matomo/ --auth-config=/path/to/auth.cfg \
  --enable-http-errors --enable-http-redirects --enable-static --enable-bots \
  --idsite=1 --recorders=4 --log-format-name=nginx_json -
 ```

--- a/import_logs.py
+++ b/import_logs.py
@@ -1088,7 +1088,15 @@ class Configuration:
         return date
 
     def _has_option(self, argv, name):
-        return any(arg == name or arg.startswith(name + '=') for arg in argv)
+        for arg in argv:
+            # '--' marks the end of options; any following values are positional args.
+            if arg == '--':
+                break
+
+            if arg == name or arg.startswith(name + '='):
+                return True
+
+        return False
 
     def _warn_if_insecure_auth_options_used(self, argv):
         insecure_options = []
@@ -1163,18 +1171,20 @@ class Configuration:
         cli_has_login = self._has_option(argv, '--login')
         cli_has_password = self._has_option(argv, '--password')
 
-        auth_config_credentials = None
-        if self.options.auth_config_file:
-            auth_config_credentials = self._load_auth_config(self.options.auth_config_file)
-
         # Explicit source precedence:
         # 1) CLI --token-auth
         # 2) CLI --login + --password
         # 3) --auth-config (token_auth, else login/password)
         # 4) --config fallback in _get_token_auth()
         if cli_has_token_auth:
+            token_auth = (self.options.matomo_token_auth or '').strip()
+            if not token_auth:
+                fatal_error("Option --token-auth requires a non-empty value.")
+
             if self.options.auth_config_file:
                 logging.info("Ignoring --auth-config credentials because --token-auth was provided.")
+
+            self.options.matomo_token_auth = token_auth
             self.options.login = None
             self.options.password = None
             return
@@ -1182,10 +1192,23 @@ class Configuration:
         if cli_has_login or cli_has_password:
             if not cli_has_login or not cli_has_password:
                 fatal_error("Options --login and --password must be used together.")
+
+            login = (self.options.login or '').strip()
+            password = (self.options.password or '').strip()
+            if not login or not password:
+                fatal_error("Options --login and --password must be non-empty when used together.")
+
             if self.options.auth_config_file:
                 logging.info("Ignoring --auth-config credentials because --login/--password were provided.")
+
+            self.options.login = login
+            self.options.password = password
             self.options.matomo_token_auth = None
             return
+
+        auth_config_credentials = None
+        if self.options.auth_config_file:
+            auth_config_credentials = self._load_auth_config(self.options.auth_config_file)
 
         self.options.login = None
         self.options.password = None

--- a/import_logs.py
+++ b/import_logs.py
@@ -37,6 +37,7 @@ import logging
 import argparse
 import os
 import os.path
+import stat
 import queue
 import re
 import ssl
@@ -776,22 +777,30 @@ class Configuration:
         parser.add_argument(
             '--config', dest='config_file', default=default_config,
             help=(
-                "This is only used when --login and --password is not used. "
+                "This is only used when --auth-config or --login/--password are not used. "
                 "Matomo will read the configuration file (default: %(default)s) to "
                 "fetch the Super User token_auth from the config file. "
             )
         )
         parser.add_argument(
+            '--auth-config', dest='auth_config_file', default=None,
+            help=(
+                "Path to an authentication config file. "
+                "Expected format: [auth] with token_auth=... OR login=... and password=.... "
+                "This is the recommended way to provide secrets."
+            )
+        )
+        parser.add_argument(
             '--login', dest='login',
-            help="You can manually specify the Matomo Super User login"
+            help="Deprecated and insecure: manually specify the Matomo Super User login via CLI."
         )
         parser.add_argument(
             '--password', dest='password',
-            help="You can manually specify the Matomo Super User password"
+            help="Deprecated and insecure: manually specify the Matomo Super User password via CLI."
         )
         parser.add_argument(
             '--token-auth', dest='matomo_token_auth',
-            help="Matomo user token_auth, the token_auth is found in Matomo > Settings > API. "
+            help="Deprecated and insecure via CLI. Matomo user token_auth, the token_auth is found in Matomo > Settings > API. "
                  "You must use a token_auth that has at least 'admin' or 'super user' permission. "
                  "If you use a token_auth for a non admin user, your users' IP addresses will not be tracked properly. "
         )
@@ -1078,6 +1087,83 @@ class Configuration:
 
         return date
 
+    def _warn_if_insecure_auth_options_used(self, argv):
+        def has_option(name):
+            return any(arg == name or arg.startswith(name + '=') for arg in argv)
+
+        insecure_options = []
+        if has_option('--token-auth'):
+            insecure_options.append('--token-auth')
+        if has_option('--login'):
+            insecure_options.append('--login')
+        if has_option('--password'):
+            insecure_options.append('--password')
+
+        if insecure_options:
+            logging.warning(
+                "DEPRECATION WARNING: passing authentication secrets via CLI options (%s) is insecure because "
+                "other users on the same machine can read process arguments. Use --auth-config instead.",
+                ', '.join(insecure_options),
+            )
+
+    def _warn_if_auth_config_permissions_are_too_open(self, filename):
+        if os.name == 'nt':
+            return
+
+        try:
+            mode = stat.S_IMODE(os.stat(filename).st_mode)
+        except OSError as e:
+            fatal_error("Could not stat auth config file '%s': %s" % (filename, e))
+
+        if mode & 0o077:
+            logging.warning(
+                "Authentication config file '%s' has overly permissive permissions (%03o). "
+                "Restrict it to 600.",
+                filename,
+                mode,
+            )
+
+    def _load_auth_config(self, filename):
+        if not os.path.isfile(filename):
+            fatal_error("Authentication config file '%s' does not exist or is not a file." % filename)
+
+        self._warn_if_auth_config_permissions_are_too_open(filename)
+
+        auth_config = configparser.RawConfigParser(strict=False)
+        success = len(auth_config.read(filename)) > 0
+        if not success:
+            fatal_error("Authentication config file '%s' could not be read." % filename)
+
+        if not auth_config.has_section('auth'):
+            fatal_error("Authentication config file '%s' is missing the [auth] section." % filename)
+
+        token_auth = auth_config.get('auth', 'token_auth', fallback='').strip()
+        login = auth_config.get('auth', 'login', fallback='').strip()
+        password = auth_config.get('auth', 'password', fallback='').strip()
+
+        if token_auth:
+            if not self.options.matomo_token_auth:
+                self.options.matomo_token_auth = token_auth
+            return
+
+        if login or password:
+            if not login or not password:
+                fatal_error(
+                    "Authentication config file '%s' must set both login and password when token_auth is not used."
+                    % filename
+                )
+
+            if not self.options.login:
+                self.options.login = login
+            if not self.options.password:
+                self.options.password = password
+            return
+
+        fatal_error(
+            "Authentication config file '%s' does not contain token_auth or login/password in the [auth] section."
+            % filename
+        )
+
     def _parse_args(self, option_parser, argv = None):
         """
         Parse the command line args and create self.options and self.filenames.
@@ -1104,6 +1190,11 @@ class Configuration:
             format='%(asctime)s: [%(levelname)s] %(message)s',
             level=logging.DEBUG if self.options.debug >= 1 else logging.INFO,
         )
+
+        self._warn_if_insecure_auth_options_used(argv)
+
+        if self.options.auth_config_file:
+            self._load_auth_config(self.options.auth_config_file)
 
         self.options.excluded_useragents = set([s.lower() for s in self.options.excluded_useragents])
 
@@ -1244,9 +1335,9 @@ class Configuration:
                     if processWin.returncode == 0:
                         phpBinary = stdout.strip()
                     else:
-                        fatal_error("We couldn't detect PHP. It might help to add your php.exe to the path or alternatively run the importer using the --login and --password option")
+                        fatal_error("We couldn't detect PHP. It might help to add your php.exe to the path or use --auth-config.")
                 except:
-                    fatal_error("We couldn't detect PHP. You can run the importer using the --login and --password option to fix this issue")
+                    fatal_error("We couldn't detect PHP. You can run the importer using --auth-config to fix this issue")
 
             command = [phpBinary, updatetokenfile]
             if self.options.enable_testmode:
@@ -1263,7 +1354,7 @@ class Configuration:
             [stdout, stderr] = process.communicate()
             stdout, stderr = stdout.decode(), stderr.decode()
             if process.returncode != 0:
-                fatal_error("`" + command + "` failed with error: " + stderr + ".\nReponse code was: " + str(process.returncode) + ". You can alternatively run the importer using the --login and --password option")
+                fatal_error("`" + command + "` failed with error: " + stderr + ".\nReponse code was: " + str(process.returncode) + ". You can alternatively run the importer using --auth-config")
 
             filename = stdout
             credentials = open(filename, 'r').readline()

--- a/import_logs.py
+++ b/import_logs.py
@@ -777,7 +777,7 @@ class Configuration:
         parser.add_argument(
             '--config', dest='config_file', default=default_config,
             help=(
-                "This is only used when --auth-config or --login/--password are not used. "
+                "This is only used when --auth-config, --token-auth, or --login/--password are not used. "
                 "Matomo will read the configuration file (default: %(default)s) to "
                 "fetch the Super User token_auth from the config file. "
             )
@@ -1087,16 +1087,16 @@ class Configuration:
 
         return date
 
-    def _warn_if_insecure_auth_options_used(self, argv):
-        def has_option(name):
-            return any(arg == name or arg.startswith(name + '=') for arg in argv)
+    def _has_option(self, argv, name):
+        return any(arg == name or arg.startswith(name + '=') for arg in argv)
 
+    def _warn_if_insecure_auth_options_used(self, argv):
         insecure_options = []
-        if has_option('--token-auth'):
+        if self._has_option(argv, '--token-auth'):
             insecure_options.append('--token-auth')
-        if has_option('--login'):
+        if self._has_option(argv, '--login'):
             insecure_options.append('--login')
-        if has_option('--password'):
+        if self._has_option(argv, '--password'):
             insecure_options.append('--password')
 
         if insecure_options:
@@ -1142,9 +1142,7 @@ class Configuration:
         password = auth_config.get('auth', 'password', fallback='').strip()
 
         if token_auth:
-            if not self.options.matomo_token_auth:
-                self.options.matomo_token_auth = token_auth
-            return
+            return {'token_auth': token_auth, 'login': None, 'password': None}
 
         if login or password:
             if not login or not password:
@@ -1153,16 +1151,55 @@ class Configuration:
                     % filename
                 )
 
-            if not self.options.login:
-                self.options.login = login
-            if not self.options.password:
-                self.options.password = password
-            return
+            return {'token_auth': None, 'login': login, 'password': password}
 
         fatal_error(
             "Authentication config file '%s' does not contain token_auth or login/password in the [auth] section."
             % filename
         )
+
+    def _apply_auth_precedence(self, argv):
+        cli_has_token_auth = self._has_option(argv, '--token-auth')
+        cli_has_login = self._has_option(argv, '--login')
+        cli_has_password = self._has_option(argv, '--password')
+
+        auth_config_credentials = None
+        if self.options.auth_config_file:
+            auth_config_credentials = self._load_auth_config(self.options.auth_config_file)
+
+        # Explicit source precedence:
+        # 1) CLI --token-auth
+        # 2) CLI --login + --password
+        # 3) --auth-config (token_auth, else login/password)
+        # 4) --config fallback in _get_token_auth()
+        if cli_has_token_auth:
+            if self.options.auth_config_file:
+                logging.info("Ignoring --auth-config credentials because --token-auth was provided.")
+            self.options.login = None
+            self.options.password = None
+            return
+
+        if cli_has_login or cli_has_password:
+            if not cli_has_login or not cli_has_password:
+                fatal_error("Options --login and --password must be used together.")
+            if self.options.auth_config_file:
+                logging.info("Ignoring --auth-config credentials because --login/--password were provided.")
+            self.options.matomo_token_auth = None
+            return
+
+        self.options.login = None
+        self.options.password = None
+
+        if not auth_config_credentials:
+            return
+
+        if auth_config_credentials['token_auth']:
+            self.options.matomo_token_auth = auth_config_credentials['token_auth']
+            return
+
+        self.options.matomo_token_auth = None
+        self.options.login = auth_config_credentials['login']
+        self.options.password = auth_config_credentials['password']
 
     def _parse_args(self, option_parser, argv = None):
         """
@@ -1192,9 +1229,7 @@ class Configuration:
         )
 
         self._warn_if_insecure_auth_options_used(argv)
-
-        if self.options.auth_config_file:
-            self._load_auth_config(self.options.auth_config_file)
+        self._apply_auth_precedence(argv)
 
         self.options.excluded_useragents = set([s.lower() for s in self.options.excluded_useragents])
 

--- a/import_logs.py
+++ b/import_logs.py
@@ -1316,7 +1316,9 @@ class Configuration:
             success = len(config_file.read(self.options.config_file)) > 0
             if not success:
                 fatal_error(
-                    "the configuration file" + self.options.config_file + " could not be read. Please check permission. This file must be readable by the user running this script to get the authentication token"
+                    "No authentication was provided and the configuration file '%s' could not be read "
+                    "(missing or unreadable). If your Matomo instance is remote/external, use --auth-config "
+                    "to provide credentials securely." % self.options.config_file
                 )
 
             updatetokenfile = os.path.abspath(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1275,6 +1275,49 @@ def test_auth_config_login_password_used_for_token_fetch(tmp_path, monkeypatch):
 
     assert config._get_token_auth() == 'generated_token'
 
+def test_cli_login_password_take_precedence_over_auth_config_token(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\ntoken_auth = file_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    argv = [
+        "--url=http://localhost",
+        "--auth-config=%s" % str(auth_config),
+        "--login=cli_user",
+        "--password=cli_secret",
+        "-"
+    ]
+    config = import_logs.Configuration(argv)
+
+    class DummyMatomo:
+        def call_api(self, method, **kwargs):
+            assert method == 'UsersManager.createAppSpecificTokenAuth'
+            assert kwargs['userLogin'] == 'cli_user'
+            assert kwargs['passwordConfirmation'] == 'cli_secret'
+            return {'value': 'generated_token'}
+
+    monkeypatch.setattr(import_logs, 'matomo', DummyMatomo(), raising=False)
+
+    assert config.options.matomo_token_auth is None
+    assert config._get_token_auth() == 'generated_token'
+
+def test_cli_token_auth_takes_precedence_over_auth_config(tmp_path):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\ntoken_auth = file_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    argv = [
+        "--url=http://localhost",
+        "--auth-config=%s" % str(auth_config),
+        "--token-auth=cli_token",
+        "-"
+    ]
+    config = import_logs.Configuration(argv)
+
+    assert config.options.matomo_token_auth == 'cli_token'
+    assert config.options.login is None
+    assert config.options.password is None
+
 def test_insecure_cli_auth_args_emit_deprecation_warning(caplog):
     argv = ["--url=http://localhost", "--token-auth=abcd", "-"]
     import_logs.Configuration(argv)
@@ -1296,6 +1339,50 @@ def test_auth_config_permissions_warning(tmp_path, caplog):
 
     messages = [record.getMessage() for record in caplog.records]
     assert any('overly permissive permissions' in message for message in messages)
+
+def test_auth_config_missing_auth_section_raises_error(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[not_auth]\ntoken_auth = test_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    try:
+        import_logs.Configuration(["--url=http://localhost", "--auth-config=%s" % str(auth_config), "-"])
+        assert False
+    except RuntimeError as e:
+        assert "missing the [auth] section" in str(e)
+
+def test_auth_config_partial_login_password_raises_error(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\nlogin = superuser\n')
+    os.chmod(str(auth_config), 0o600)
+
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    try:
+        import_logs.Configuration(["--url=http://localhost", "--auth-config=%s" % str(auth_config), "-"])
+        assert False
+    except RuntimeError as e:
+        assert 'must set both login and password' in str(e)
+
+def test_cli_partial_login_password_raises_error(monkeypatch):
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    try:
+        import_logs.Configuration(["--url=http://localhost", "--login=superuser", "-"])
+        assert False
+    except RuntimeError as e:
+        assert 'must be used together' in str(e)
 
 def test_missing_config_file_error_mentions_auth_config(monkeypatch):
     config = import_logs.Configuration(["--url=http://localhost", "--config=/tmp/definitely_missing_config_file.ini.php", "-"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1246,6 +1246,57 @@ def test_glob_filenames():
 
     assert config.filenames == ['logs/common.log', 'logs/common_complete.log', 'logs/common_encoding_big5.log', 'logs/common_vhost.log', 'logs/elb.log']
 
+def test_auth_config_sets_token_auth(tmp_path):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\ntoken_auth = test_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    argv = ["--url=http://localhost", "--auth-config=%s" % str(auth_config), "-"]
+    config = import_logs.Configuration(argv)
+
+    assert config.options.matomo_token_auth == 'test_token'
+
+def test_auth_config_login_password_used_for_token_fetch(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\nlogin = superuser\npassword = secret\n')
+    os.chmod(str(auth_config), 0o600)
+
+    argv = ["--url=http://localhost", "--auth-config=%s" % str(auth_config), "-"]
+    config = import_logs.Configuration(argv)
+
+    class DummyMatomo:
+        def call_api(self, method, **kwargs):
+            assert method == 'UsersManager.createAppSpecificTokenAuth'
+            assert kwargs['userLogin'] == 'superuser'
+            assert kwargs['passwordConfirmation'] == 'secret'
+            return {'value': 'generated_token'}
+
+    monkeypatch.setattr(import_logs, 'matomo', DummyMatomo(), raising=False)
+
+    assert config._get_token_auth() == 'generated_token'
+
+def test_insecure_cli_auth_args_emit_deprecation_warning(caplog):
+    argv = ["--url=http://localhost", "--token-auth=abcd", "-"]
+    import_logs.Configuration(argv)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any('DEPRECATION WARNING' in message for message in messages)
+    assert any('--token-auth' in message for message in messages)
+
+def test_auth_config_permissions_warning(tmp_path, caplog):
+    if os.name == 'nt':
+        return
+
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\ntoken_auth = test_token\n')
+    os.chmod(str(auth_config), 0o644)
+
+    argv = ["--url=http://localhost", "--auth-config=%s" % str(auth_config), "-"]
+    import_logs.Configuration(argv)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any('overly permissive permissions' in message for message in messages)
+
 # UrlHelper tests
 def test_urlhelper_convert_array_args():
     def _test(input, expected):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1318,6 +1318,104 @@ def test_cli_token_auth_takes_precedence_over_auth_config(tmp_path):
     assert config.options.login is None
     assert config.options.password is None
 
+def test_cli_token_auth_ignores_missing_auth_config(monkeypatch):
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    config = import_logs.Configuration([
+        "--url=http://localhost",
+        "--auth-config=/tmp/definitely_missing_auth_config.cfg",
+        "--token-auth=cli_token",
+        "-"
+    ])
+
+    assert config.options.matomo_token_auth == 'cli_token'
+
+def test_double_dash_stops_auth_option_detection(monkeypatch, caplog):
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    config = import_logs.Configuration([
+        "--url=http://localhost",
+        "--",
+        "-",
+        "--token-auth=fake.log",
+    ])
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    assert config.options.matomo_token_auth is None
+    assert not any('DEPRECATION WARNING' in message for message in messages)
+
+def test_cli_login_password_ignores_invalid_auth_config(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'invalid_auth.cfg'
+    auth_config.write_text('[not_auth]\ntoken_auth = file_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    config = import_logs.Configuration([
+        "--url=http://localhost",
+        "--auth-config=%s" % str(auth_config),
+        "--login=cli_user",
+        "--password=cli_secret",
+        "-"
+    ])
+
+    assert config.options.login == 'cli_user'
+    assert config.options.password == 'cli_secret'
+    assert config.options.matomo_token_auth is None
+
+def test_cli_empty_token_auth_raises_error_even_with_auth_config(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\ntoken_auth = file_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    try:
+        import_logs.Configuration([
+            "--url=http://localhost",
+            "--auth-config=%s" % str(auth_config),
+            "--token-auth=",
+            "-"
+        ])
+        assert False
+    except RuntimeError as e:
+        assert '--token-auth requires a non-empty value' in str(e)
+
+def test_cli_empty_login_password_raises_error_even_with_auth_config(tmp_path, monkeypatch):
+    auth_config = tmp_path / 'auth.cfg'
+    auth_config.write_text('[auth]\ntoken_auth = file_token\n')
+    os.chmod(str(auth_config), 0o600)
+
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    try:
+        import_logs.Configuration([
+            "--url=http://localhost",
+            "--auth-config=%s" % str(auth_config),
+            "--login=",
+            "--password=",
+            "-"
+        ])
+        assert False
+    except RuntimeError as e:
+        assert '--login and --password must be non-empty' in str(e)
+
 def test_insecure_cli_auth_args_emit_deprecation_warning(caplog):
     argv = ["--url=http://localhost", "--token-auth=abcd", "-"]
     import_logs.Configuration(argv)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1297,6 +1297,22 @@ def test_auth_config_permissions_warning(tmp_path, caplog):
     messages = [record.getMessage() for record in caplog.records]
     assert any('overly permissive permissions' in message for message in messages)
 
+def test_missing_config_file_error_mentions_auth_config(monkeypatch):
+    config = import_logs.Configuration(["--url=http://localhost", "--config=/tmp/definitely_missing_config_file.ini.php", "-"])
+
+    def fake_fatal_error(message, filename=None, lineno=None):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(import_logs, 'fatal_error', fake_fatal_error)
+
+    try:
+        config._get_token_auth()
+        assert False
+    except RuntimeError as e:
+        message = str(e)
+        assert 'No authentication was provided' in message
+        assert '--auth-config' in message
+
 # UrlHelper tests
 def test_urlhelper_convert_array_args():
     def _test(input, expected):


### PR DESCRIPTION
### Summary

This PR improves authentication security for import_logs.py and updates documentation to match actual CLI behavior.

The importer previously required credentials via CLI flags (--token-auth, --login, --password), which can expose secrets in process listings (ps, htop) on shared systems.
This PR adds a safer config-file based auth path and deprecates CLI secret input.

### What Changed

#### Auth code changes

- Added --auth-config=<path> support.
- Implemented auth config parsing from [auth]:
    - token_auth = ...
    - or login = ... + password = ...
- Added permission checks for auth config files and warning when permissions are too open (recommended 600).
- Added deprecation warnings when secrets are passed via CLI:
    - --token-auth
    - --login
    - --password
- Updated related error messages to recommend --auth-config.

#### Tests

Added auth-focused tests for:

- loading token from --auth-config
- loading login/password from --auth-config and fetching token via API call
- deprecation warning emission for insecure CLI secret flags
- warning for overly permissive auth config permissions

#### README updates

- Corrected docs to match actual CLI/auth behavior.
- Added/updated secure auth guidance around --auth-config.
- Corrected outdated examples/flags and usage notes.
- Clarified authentication method behavior and fixed stale references.

### Backward Compatibility

- Existing CLI auth flags still work for now, but are now explicitly deprecated and warned.
- No runtime behavior removed in this PR.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
