### PR TITLE
[Patch available] --enable-bots: Support Custom Dimensions as replace…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,10 @@
 - Always disable queued tracking when sending requests from log import (#274)
 - added support for Python 3.5 and above (#267)
 - dropped support for Python 2.x (#267)
+
+ 
+## Unreleased
+- Extended `--enable-bots` to accept a Custom Dimension ID (`--enable-bots=N`),
+  storing classified bot names in the dimension instead of deprecated Custom Variables.
+  Non-bot visits receive 'Not a Bot'. Recommended for Matomo 5+. (#394)
+- Added AI/LLM crawlers (GPTBot, ClaudeBot, PerplexityBot, etc.) to bot exclusion list.

--- a/import_logs.py
+++ b/import_logs.py
@@ -957,13 +957,16 @@ class Configuration:
         )
         parser.add_argument(
             '--enable-bots', dest='enable_bots',
-            nargs='?', const=True, default=None,
+            action='store_true', default=False,
+            help="Track bots. All bot visits will have a Custom Variable set with name='Bot' and value='$Bot_user_agent_here$'"
+        )
+        parser.add_argument(
+            '--bot-custom-dimension', dest='bot_custom_dimension',
+            type=int, default=None,
             metavar='DIMENSION_ID',
-            help="Track bots. When used without a value (--enable-bots), bot visits will have a Custom Variable "
-                 "set with name='Bot' and value='$Bot_user_agent_here$' (requires the CustomVariables plugin). "
-                 "When used with a Custom Dimension ID (--enable-bots=1), the bot name is stored in that dimension "
-                 "instead, which is the recommended approach for Matomo 5+ where Custom Variables are deprecated. "
-                 "Non-bot visits receive 'Not a Bot' in the dimension."
+            help="Store the bot name in the given Custom Dimension ID instead of a Custom Variable "
+                 "(recommended for Matomo 5+ where Custom Variables are deprecated). "
+                 "Requires --enable-bots. Non-bot visits receive 'Not a Bot' in the dimension."
         )
         parser.add_argument(
             '--enable-http-errors', dest='enable_http_errors',
@@ -2338,16 +2341,8 @@ class Recorder:
 
         # handle bot tracking
         if config.options.enable_bots:
-            if config.options.enable_bots is True:
-                dimension_id = None
-            else:
-                try:
-                    dimension_id = int(config.options.enable_bots)
-                except (TypeError, ValueError):
-                    dimension_id = None
-
-            if dimension_id is not None:
-                dim_key = 'dimension%d' % dimension_id
+            if config.options.bot_custom_dimension is not None:
+                dim_key = 'dimension%d' % config.options.bot_custom_dimension
                 if hit.is_robot:
                     hit.args[dim_key] = _get_bot_name_for_custom_dimension(hit.user_agent)
                 else:
@@ -2386,7 +2381,7 @@ class Recorder:
         if hit.is_download:
             args['download'] = args['url']
 
-        if config.options.enable_bots:
+        if config.options.enable_bots or config.options.bot_custom_dimension is not None:
             args['bots'] = '1'
 
         if hit.is_error or hit.is_redirect:
@@ -2617,7 +2612,7 @@ class Parser:
         user_agent = hit.user_agent.lower()
         for s in itertools.chain(EXCLUDED_USER_AGENTS, config.options.excluded_useragents):
             if s in user_agent:
-                if config.options.enable_bots:
+                if config.options.enable_bots or config.options.bot_custom_dimension is not None:
                     hit.is_robot = True
                     return True
                 else:

--- a/import_logs.py
+++ b/import_logs.py
@@ -84,35 +84,148 @@ DOWNLOAD_EXTENSIONS = set((
 # user agents must be lowercase
 EXCLUDED_USER_AGENTS = (
     'adsbot-google',
+    'amazonbot',
+    'anthropic-ai',
+    'applebot',
+    'archive.org_bot',
+    'aranet-searchbot',
     'ask jeeves',
+    'awariobot',
     'baidubot',
+    'bitsightbot',
     'bot-',
     'bot/',
+    'bytespider',
+    'ccbot',
     'ccooter/',
+    'chatgpt-user',
+    'claude-web',
+    'claudebot',
+    'codabot',
+    'cohere-ai',
     'crawl',
     'curl',
+    'dataforseobot',
+    'diffbot',
+    'duckassistbot',
     'echoping',
     'exabot',
+    'facebookbot',
     'feed',
+    'google-extended',
     'googlebot',
+    'googleother',
     'ia_archiver',
     'java/',
     'libwww',
     'mediapartners-google',
+    'meta-externalagent',
     'msnbot',
     'netcraftsurvey',
+    'oai-searchbot',
     'panopta',
+    'petalbot',
+    'perplexitybot',
     'pingdom.com_bot_',
+    'qwantbot',
     'robot',
+    'seznambot',
+    'sleepbot',
     'spider',
     'surveybot',
+    'thinkers-bot',
+    'tiktokspider',
+    'trendictionbot',
     'twiceler',
     'voilabot',
     'yahoo',
     'yandex',
+    'youbot',
     'zabbix',
     'googlestackdrivermonitoring',
 )
+
+# Known bot user agent patterns mapped to display names, used with --bot-custom-dimension.
+# Patterns must be lowercase substrings of the user agent string.
+BOT_CUSTOM_DIMENSION_NAMES = [
+    # AI / LLM bots
+    ('GPTBot',               'gptbot'),
+    ('ChatGPT-User',         'chatgpt-user'),
+    ('OAI-SearchBot',        'oai-searchbot'),
+    ('ClaudeBot',            'claudebot'),
+    ('Claude-Web',           'claude-web'),
+    ('Anthropic-AI',         'anthropic-ai'),
+    ('Google-Extended',      'google-extended'),
+    ('GoogleOther',          'googleother'),
+    ('PerplexityBot',        'perplexitybot'),
+    ('Bytespider',           'bytespider'),
+    ('CCBot',                'ccbot'),
+    ('AmazonBot',            'amazonbot'),
+    ('Cohere-AI',            'cohere-ai'),
+    ('YouBot',               'youbot'),
+    ('Diffbot',              'diffbot'),
+    ('FacebookBot',          'facebookbot'),
+    ('DataForSeoBot',        'dataforseobot'),
+    ('PetalBot',             'petalbot'),
+    # Search engine bots
+    ('Googlebot',            'googlebot'),
+    ('AdsBot-Google',        'adsbot-google'),
+    ('Mediapartners-Google', 'mediapartners-google'),
+    ('Bingbot',              'bingbot'),
+    ('MSNBot',               'msnbot'),
+    ('Yahoo-Slurp',          'slurp'),
+    ('DuckDuckBot',          'duckduckbot'),
+    ('Baiduspider',          'baiduspider'),
+    ('YandexBot',            'yandex'),
+    ('SogouBot',             'sogou'),
+    ('Exabot',               'exabot'),
+    ('Wayback-Machine',      'ia_archiver'),
+    # SEO bots
+    ('SemrushBot',           'semrushbot'),
+    ('AhrefsBot',            'ahrefsbot'),
+    ('MJ12bot',              'mj12bot'),
+    ('DotBot',               'dotbot'),
+    ('Rogerbot',             'rogerbot'),
+    ('Blexbot',              'blexbot'),
+    ('BitSightBot',          'bitsightbot'),
+    # Other crawlers
+    ('SleepBot',             'sleepbot'),
+    ('AwarioBot',            'awariobot'),
+    ('Qwantbot',             'qwantbot'),
+    ('archive.org_bot',      'archive.org_bot'),
+    ('Aranet-SearchBot',     'aranet-searchbot'),
+    ('CodaBot',              'codabot'),
+    ('thinkers-bot',         'thinkers-bot'),
+    ('trendictionbot',       'trendictionbot'),
+    ('SeznamBot',            'seznambot'),
+    # Social media bots
+    ('Applebot',             'applebot'),
+    ('Meta-ExternalAgent',   'meta-externalagent'),
+    ('TikTokSpider',         'tiktokspider'),
+    ('FacebookExternalHit',  'facebookexternalhit'),
+    ('Twitterbot',           'twitterbot'),
+    ('LinkedInBot',          'linkedinbot'),
+    ('WhatsApp',             'whatsapp'),
+    ('TelegramBot',          'telegrambot'),
+    ('Slackbot',             'slackbot'),
+    ('Discordbot',           'discordbot'),
+    ('DuckAssistBot',        'duckassistbot'),
+    # Monitoring bots
+    ('Pingdom',              'pingdom'),
+    ('UptimeRobot',          'uptimerobot'),
+    ('Zabbix',               'zabbix'),
+    ('Panopta',              'panopta'),
+    ('NetcraftSurvey',       'netcraftsurvey'),
+    ('StackdriverMonitoring','googlestackdrivermonitoring'),
+]
+
+def _get_bot_name_for_custom_dimension(user_agent):
+    ua = user_agent.lower()
+    for name, pattern in BOT_CUSTOM_DIMENSION_NAMES:
+        if pattern in ua:
+            return name
+    return 'Other Bot'
+
 
 MATOMO_DEFAULT_MAX_ATTEMPTS = 3
 MATOMO_DEFAULT_DELAY_AFTER_FAILURE = 10
@@ -844,8 +957,13 @@ class Configuration:
         )
         parser.add_argument(
             '--enable-bots', dest='enable_bots',
-            action='store_true', default=False,
-            help="Track bots. All bot visits will have a Custom Variable set with name='Bot' and value='$Bot_user_agent_here$'"
+            nargs='?', const=True, default=None,
+            metavar='DIMENSION_ID',
+            help="Track bots. When used without a value (--enable-bots), bot visits will have a Custom Variable "
+                 "set with name='Bot' and value='$Bot_user_agent_here$' (requires the CustomVariables plugin). "
+                 "When used with a Custom Dimension ID (--enable-bots=1), the bot name is stored in that dimension "
+                 "instead, which is the recommended approach for Matomo 5+ where Custom Variables are deprecated. "
+                 "Non-bot visits receive 'Not a Bot' in the dimension."
         )
         parser.add_argument(
             '--enable-http-errors', dest='enable_http_errors',
@@ -2218,12 +2336,23 @@ class Recorder:
         url_prefix = self._get_host_with_protocol(hit.host, main_url) if hasattr(hit, 'host') else main_url
         url = (url_prefix if path.startswith('/') else '') + path[:1024]
 
-        # handle custom variables before generating args dict
+        # handle bot tracking
         if config.options.enable_bots:
-            if hit.is_robot:
-                hit.add_visit_custom_var("Bot", hit.user_agent)
+            try:
+                dimension_id = int(config.options.enable_bots)
+            except (TypeError, ValueError):
+                dimension_id = None
+            if dimension_id is not None:
+                dim_key = 'dimension%d' % dimension_id
+                if hit.is_robot:
+                    hit.args[dim_key] = _get_bot_name_for_custom_dimension(hit.user_agent)
+                else:
+                    hit.args[dim_key] = 'Not a Bot'
             else:
-                hit.add_visit_custom_var("Not-Bot", hit.user_agent)
+                if hit.is_robot:
+                    hit.add_visit_custom_var("Bot", hit.user_agent)
+                else:
+                    hit.add_visit_custom_var("Not-Bot", hit.user_agent)
 
         hit.add_page_custom_var("HTTP-code", hit.status)
 

--- a/import_logs.py
+++ b/import_logs.py
@@ -2338,10 +2338,14 @@ class Recorder:
 
         # handle bot tracking
         if config.options.enable_bots:
-            try:
-                dimension_id = int(config.options.enable_bots)
-            except (TypeError, ValueError):
+            if config.options.enable_bots is True:
                 dimension_id = None
+            else:
+                try:
+                    dimension_id = int(config.options.enable_bots)
+                except (TypeError, ValueError):
+                    dimension_id = None
+
             if dimension_id is not None:
                 dim_key = 'dimension%d' % dimension_id
                 if hit.is_robot:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,10 @@ from collections import OrderedDict
 
 import import_logs
 
+# Keep a reference to the real Recorder class before any test replaces import_logs.Recorder
+# with a mock instance, so unit tests can call _get_hit_args() directly.
+_RealRecorder = import_logs.Recorder
+
 
 # utility functions
 def add_junk_to_file(path):
@@ -167,7 +171,12 @@ class Options(object):
         self.hostnames = []
         self.excluded_paths = []
         self.excluded_useragents = []
-        self.enable_bots = []
+        self.enable_bots = False
+        self.bot_custom_dimension = None
+        self.use_bulk_tracking = True
+        self.strip_query_string = False
+        self.reverse_dns = False
+        self.title_category_delimiter = '/'
         self.force_lowercase_path = False
         self.included_paths = []
         self.enable_http_errors = False
@@ -201,6 +210,14 @@ class Resolver(object):
     """Mock resolver which doesn't check connection to real piwik."""
     def check_format(self, format_):
         pass
+
+class BotResolver(object):
+    """Mock resolver for bot tracking tests that returns a fixed site ID."""
+    def check_format(self, format_):
+        pass
+
+    def resolve(self, hit):
+        return (1, 'http://example.com')
 
 class Recorder(object):
     """Mock recorder which collects hits but doesn't put their in database."""
@@ -1593,6 +1610,33 @@ def test_bz2_parsing():
     assert hits[0]['userid'] == 'theboss'
     
     
+def _make_bot_hit(user_agent, is_robot=True):
+    """Construct a minimal Hit object for bot tracking unit tests."""
+    return import_logs.Hit(
+        args={},
+        ip='1.2.3.4',
+        host='example.com',
+        path='/page',
+        query_string='',
+        referrer='',
+        user_agent=user_agent,
+        date=datetime.datetime(2024, 1, 1, 0, 0, 0),
+        status='200',
+        length=100,
+        is_robot=is_robot,
+        is_error=False,
+        is_redirect=False,
+        is_download=False,
+        generation_time_milli=0,
+        event_category=None,
+        event_action=None,
+        event_name=None,
+        filename='test.log',
+        lineno=1,
+        full_path='/page',
+    )
+
+
 def test_get_bot_name_for_custom_dimension():
     """Test bot name lookup from user agent string."""
     assert import_logs._get_bot_name_for_custom_dimension('Mozilla/5.0 (compatible; GPTBot/1.0)') == 'GPTBot'
@@ -1603,46 +1647,44 @@ def test_get_bot_name_for_custom_dimension():
 
 
 def test_enable_bots_custom_variable_fallback():
-    """--enable-bots without value stores bot info in Custom Variable (backward compat)."""
-    file_ = 'logs/ncsa_extended.log'
-
+    """--enable-bots without --bot-custom-dimension stores bot UA in a Custom Variable (backward compat)."""
     import_logs.stats = import_logs.Statistics()
     import_logs.config = Config()
-    import_logs.config.options.enable_bots = True  # kein Dimension-ID
-    import_logs.config.options.enable_http_errors = False
-    import_logs.config.options.enable_http_redirects = False
-    import_logs.config.options.enable_static = False
-    import_logs.config.options.download_extensions = 'doc,pdf'
-    import_logs.resolver = Resolver()
-    import_logs.Recorder = Recorder()
-    import_logs.parser = import_logs.Parser()
-    import_logs.parser.parse(file_)
+    import_logs.config.options.enable_bots = True
+    import_logs.config.options.bot_custom_dimension = None
+    import_logs.resolver = BotResolver()
+    Recorder.recorders = []
 
-    for hit in Recorder.recorders:
-        if hit.is_robot:
-            assert 'dimension1' not in hit.args
-            break
+    bot_hit = _make_bot_hit('Mozilla/5.0 (compatible; GPTBot/1.0)')
+    recorder = _RealRecorder()
+    recorder._get_hit_args(bot_hit)
+
+    assert 'dimension1' not in bot_hit.args
+    assert '_cvar' in bot_hit.args
+
+    non_bot_hit = _make_bot_hit('Mozilla/5.0 Chrome/120.0', is_robot=False)
+    recorder._get_hit_args(non_bot_hit)
+
+    assert 'dimension1' not in non_bot_hit.args
+    assert '_cvar' in non_bot_hit.args
 
 
 def test_enable_bots_custom_dimension():
-    """--enable-bots=1 stores classified bot name in Custom Dimension 1."""
-    file_ = 'logs/ncsa_extended.log'
-
+    """--enable-bots --bot-custom-dimension=1 stores classified bot name in Custom Dimension 1."""
     import_logs.stats = import_logs.Statistics()
     import_logs.config = Config()
-    import_logs.config.options.enable_bots = '1'  # Dimension-ID als String
-    import_logs.config.options.enable_http_errors = False
-    import_logs.config.options.enable_http_redirects = False
-    import_logs.config.options.enable_static = False
-    import_logs.config.options.download_extensions = 'doc,pdf'
-    import_logs.resolver = Resolver()
-    import_logs.Recorder = Recorder()
-    import_logs.parser = import_logs.Parser()
-    import_logs.parser.parse(file_)
+    import_logs.config.options.enable_bots = True
+    import_logs.config.options.bot_custom_dimension = 1
+    import_logs.resolver = BotResolver()
+    Recorder.recorders = []
 
-    for hit in Recorder.recorders:
-        assert 'dimension1' in hit.args
-        assert hit.args['dimension1'] in (
-            [name for name, _ in import_logs.BOT_CUSTOM_DIMENSION_NAMES] + ['Other Bot', 'Not a Bot']
-        )
-        break
+    bot_hit = _make_bot_hit('Mozilla/5.0 (compatible; GPTBot/1.0)')
+    recorder = _RealRecorder()
+    recorder._get_hit_args(bot_hit)
+
+    assert bot_hit.args.get('dimension1') == 'GPTBot'
+
+    non_bot_hit = _make_bot_hit('Mozilla/5.0 Chrome/120.0', is_robot=False)
+    recorder._get_hit_args(non_bot_hit)
+
+    assert non_bot_hit.args.get('dimension1') == 'Not a Bot'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1591,3 +1591,58 @@ def test_bz2_parsing():
     assert hits[0]['status'] == '200'
     assert hits[0]['length'] == 444
     assert hits[0]['userid'] == 'theboss'
+    
+    
+def test_get_bot_name_for_custom_dimension():
+    """Test bot name lookup from user agent string."""
+    assert import_logs._get_bot_name_for_custom_dimension('Mozilla/5.0 (compatible; GPTBot/1.0)') == 'GPTBot'
+    assert import_logs._get_bot_name_for_custom_dimension('Mozilla/5.0 (compatible; ClaudeBot/1.0)') == 'ClaudeBot'
+    assert import_logs._get_bot_name_for_custom_dimension('Mozilla/5.0 (compatible; Googlebot/2.1)') == 'Googlebot'
+    assert import_logs._get_bot_name_for_custom_dimension('Mozilla/5.0 (compatible; bingbot/2.0)') == 'Bingbot'
+    assert import_logs._get_bot_name_for_custom_dimension('Mozilla/5.0 (Windows NT 10.0) Chrome/120.0') == 'Other Bot'
+
+
+def test_enable_bots_custom_variable_fallback():
+    """--enable-bots without value stores bot info in Custom Variable (backward compat)."""
+    file_ = 'logs/ncsa_extended.log'
+
+    import_logs.stats = import_logs.Statistics()
+    import_logs.config = Config()
+    import_logs.config.options.enable_bots = True  # kein Dimension-ID
+    import_logs.config.options.enable_http_errors = False
+    import_logs.config.options.enable_http_redirects = False
+    import_logs.config.options.enable_static = False
+    import_logs.config.options.download_extensions = 'doc,pdf'
+    import_logs.resolver = Resolver()
+    import_logs.Recorder = Recorder()
+    import_logs.parser = import_logs.Parser()
+    import_logs.parser.parse(file_)
+
+    for hit in Recorder.recorders:
+        if hit.is_robot:
+            assert 'dimension1' not in hit.args
+            break
+
+
+def test_enable_bots_custom_dimension():
+    """--enable-bots=1 stores classified bot name in Custom Dimension 1."""
+    file_ = 'logs/ncsa_extended.log'
+
+    import_logs.stats = import_logs.Statistics()
+    import_logs.config = Config()
+    import_logs.config.options.enable_bots = '1'  # Dimension-ID als String
+    import_logs.config.options.enable_http_errors = False
+    import_logs.config.options.enable_http_redirects = False
+    import_logs.config.options.enable_static = False
+    import_logs.config.options.download_extensions = 'doc,pdf'
+    import_logs.resolver = Resolver()
+    import_logs.Recorder = Recorder()
+    import_logs.parser = import_logs.Parser()
+    import_logs.parser.parse(file_)
+
+    for hit in Recorder.recorders:
+        assert 'dimension1' in hit.args
+        assert hit.args['dimension1'] in (
+            [name for name, _ in import_logs.BOT_CUSTOM_DIMENSION_NAMES] + ['Other Bot', 'Not a Bot']
+        )
+        break


### PR DESCRIPTION
Fixes #392

…ment for deprecated Custom Variables

Add--enable-bots does not work on Matomo 5.10 (Custom Variables deprecated)

On Matomo 5.10 the CustomVariables plugin is no longer part of core and must be installed separately from the Marketplace. When the plugin is not available, --enable-bots silently fails to store any bot information.. the flag still includes bot traffic, but the _cvar data is discarded by the tracker.

Proposed fix

Extend --enable-bots to optionally accept a Custom Dimension ID:

--enable-bots → existing behavior, backward compatible --enable-bots=1 → stores the classified bot name in Custom Dimension 1 (recommended for Matomo 5.*) This adds a built-in bot classification table (GPTBot, Bingbot, ClaudeBot, SemrushBot, etc.) and uses dimension{N} in the tracker request instead of _cvar.

Non-bot visits receive Not a Bot in the dimension, allowing easy segmentation.

Motivation

Custom Dimensions are the official replacement for Custom Variables in Matomo 5 (see deprecation notice). The log importer should reflect this.ed new bot user agents and updated bot tracking logic.

### Description

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
