### PR TITLE
Fixing comment on _call_wrapper

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1887,7 +1887,7 @@ class MatomoHttpUrllib(MatomoHttpBase):
 
     def _call_wrapper(self, func, expected_response, on_failure, *args, **kwargs):
         """
-        Try to make requests to Matomo at most MATOMO_FAILURE_MAX_RETRY times.
+        Try to make requests to Matomo at most MATOMO_DEFAULT_MAX_ATTEMPTS times.
         """
         errors = 0
         while True:


### PR DESCRIPTION
MATOMO_FAILURE_MAX_RETRY should be MATOMO_DEFAULT_MAX_ATTEMPTS. Or maybe ''max_attempts"?

### Description

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
